### PR TITLE
fix: unparenthesized deprecated error in composer

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -69,7 +69,7 @@ class Service
 
         $headers = $takes->transform(function ($item) {
             if ($item == 'authorization') {
-                $item = isset($_SERVER['HTTP_AUTHORIZATION']) ? $_SERVER['HTTP_AUTHORIZATION'] : (app('request')->header('Authorization')) ? app('request')->header('Authorization') : 'authorization';
+                $item = isset($_SERVER['HTTP_AUTHORIZATION']) ? $_SERVER['HTTP_AUTHORIZATION'] : (app('request')->header('Authorization') ? app('request')->header('Authorization') : 'authorization');
             }
             if ($item == 'accept') {
                 $item = isset($_SERVER['HTTP_ACCEPT']) ? $_SERVER['HTTP_ACCEPT'] : 'application/json';


### PR DESCRIPTION
fixing issue when use composer

```bash
> @php artisan package:discover

In Service.php line 72:
                                                                               
  Unparenthesized `a ? b : c ? d : e` is deprecated. Use either `(a ? b : c)   
  ? d : e` or `a ? b : (c ? d : e)` 
```