### PR TITLE
Feat#cache configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
     <?php
 
     return [
-    
+
         /*
         |--------------------------------------------------------------------------
         | Encryption Key
@@ -46,11 +46,11 @@
         | will not be safe. Please do this before deploying an application!
         |
         */
-    
+
         'key' => env('APP_KEY'),
-    
+
         'cipher' => 'AES-256-CBC',
-    
+
         /*
         |--------------------------------------------------------------------------
         | Hash
@@ -59,9 +59,9 @@
         | This key is used by the SRC Service
         |
         */
-    
+
         'hash' => 'sha256',
-    
+
         /*
         |--------------------------------------------------------------------------
         | Expire
@@ -72,7 +72,7 @@
         | they have less time to be guessed. You may change this as needed.
         |
         */
-    
+
         'expire' => 14400,
 
         /*
@@ -84,8 +84,23 @@
         |
         */
 
-        'cache_expire' => 3600
-    
+        'cache_expire' => 600,
+
+        /*
+        |--------------------------------------------------------------------------
+        | Default Cache Store
+        |--------------------------------------------------------------------------
+        |
+        | This option controls the default cache connection that gets used while
+        | using this caching library. This connection is used when another is
+        | not explicitly specified when executing a given caching function.
+        |
+        | Supported: "apc", "array", "database", "file", "memcached", "redis"
+        |
+        */
+
+        'cache_driver' => env('CACHE_DRIVER', 'file')
+
     ];
     ```
 - Daftarkan file konfigurasi

--- a/config/srcservice.php
+++ b/config/srcservice.php
@@ -50,6 +50,21 @@ return [
     |
     */
 
-    'cache_expire' => 600
+    'cache_expire' => 600,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Cache Store
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default cache connection that gets used while
+    | using this caching library. This connection is used when another is
+    | not explicitly specified when executing a given caching function.
+    |
+    | Supported: "apc", "array", "database", "file", "memcached", "redis"
+    |
+    */
+
+    'cache_driver' => env('CACHE_DRIVER', 'file')
 
 ];

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -172,6 +172,39 @@ class Auth
     }
 
     /**
+     * Clear auth cache
+     *
+     * @return void
+     */
+    public static function cacheClear()
+    {
+        try {
+            if ($auth = self::cache('auth')) {
+                // remove auth cache
+                self::onCache()->forget(self::cacheKey('auth'));
+
+                // remove user cache
+                self::onCache()->forget(self::cacheKey([
+                    'user',
+                    $auth->user_id
+                ]));
+            }
+        } catch (\Exception $e) {
+            // do nothing
+        }
+    }
+
+    /**
+     * Use Cache
+     *
+     * @return \Illuminate\Cache\Repository
+     */
+    protected static function onCache(): \Illuminate\Cache\Repository
+    {
+        return Cache::driver(self::cacheDriver());
+    }
+
+    /**
      * Get Cache
      *
      * @param string|array $key
@@ -179,9 +212,7 @@ class Auth
      */
     protected static function cache($key)
     {
-        $key = is_array($key) ? self::getKey(...$key) : self::getKey($key);
-
-        return Cache::driver(self::cacheDriver())->get($key);
+        return self::onCache()->get(self::cacheKey($key));
     }
 
     /**
@@ -193,9 +224,18 @@ class Auth
      */
     protected static function cachePut($key, $data)
     {
-        $key = is_array($key) ? self::getKey(...$key) : self::getKey($key);
+        self::onCache()->put(self::cacheKey($key), $data, config('srcservice.cache_expire'));
+    }
 
-        Cache::driver(self::cacheDriver())->put($key, $data, config('srcservice.cache_expire'));
+    /**
+     * Build Cache key
+     *
+     * @param mixed $key
+     * @return string
+     */
+    protected static function cacheKey($key): string
+    {
+        return is_array($key) ? self::getKey(...$key) : self::getKey($key);
     }
 
     /**

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -181,7 +181,7 @@ class Auth
     {
         $key = is_array($key) ? self::getKey(...$key) : self::getKey($key);
 
-        return Cache::get($key);
+        return Cache::driver(self::cacheDriver())->get($key);
     }
 
     /**
@@ -195,7 +195,17 @@ class Auth
     {
         $key = is_array($key) ? self::getKey(...$key) : self::getKey($key);
 
-        Cache::put($key, $data, config('srcservice.cache_expire'));
+        Cache::driver(self::cacheDriver())->put($key, $data, config('srcservice.cache_expire'));
+    }
+
+    /**
+     * Cache driver
+     *
+     * @return string|null
+     */
+    protected static function cacheDriver(): ?string
+    {
+        return config('srcservice.cache_driver');
     }
 
     /**


### PR DESCRIPTION
New Feature Added
- configurable cache driver (so it can be the same in all services)
- add new static method `Auth::cacheClear()` to clear cache (useful when revoke tokens)